### PR TITLE
Create budgets

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -6,6 +6,11 @@ Globals:
   Function:
     Timeout: 30
 
+Parameters:
+  SynapseTeamMemberListEndpoint:
+    Description: 'Endpoint to retrieve member list for a particular Synapse team'
+    Type: String
+
 Resources:
   BudgetMakerFunction:
     Type: AWS::Serverless::Function
@@ -14,11 +19,20 @@ Resources:
       Handler: app.lambda_handler
       Runtime: python3.6
       Role: !GetAtt BudgetMakerFunctionRole.Arn
+      Environment:
+        Variables:
+          NOTIFICATION_TOPIC_ARN: !Ref BudgetMakerNotificationTopic
+          SYNAPSE_TEAM_MEMBER_LIST_ENDPOINT: !Ref SynapseTeamMemberListEndpoint
+          AWS_ACCOUNT_ID: !Ref 'AWS::AccountId'
       Events:
-        FiveMinute: # Trigger every five minutes
+        OneMinute: # Trigger every minute
           Type: Schedule
           Properties:
-            Schedule: rate(5 minute)
+            Schedule: rate(1 minute)
+        # FiveMinute: # Trigger every five minutes
+        #   Type: Schedule
+        #   Properties:
+        #     Schedule: rate(5 minutes)
 
   BudgetMakerFunctionRole:
     Type: AWS::IAM::Role
@@ -34,17 +48,59 @@ Resources:
               - sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Ref BudgetMakerFunctionPolicy
+
+  BudgetMakerFunctionPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: BudgetReadWrite
+            Effect: 'Allow'
+            Action:
+              - budgets:ViewBudget
+              - budgets:ModifyBudget
+            Resource: '*'
+
+  BudgetMakerNotificationTopic:
+    Type: AWS::SNS::Topic
+
+  BudgetMakerNotificationTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Sid: BudgetNotificationPublication
+          Effect: Allow
+          Principal:
+            Service: 'budgets.amazonaws.com'
+          Action: sns:Publish
+          Resource: '*'
+      Topics:
+        - !Ref BudgetMakerNotificationTopic
 
 Outputs:
-  # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
-  # Find out more about other implicit resources you can reference within SAM
-  # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
-  # HelloWorldApi:
-  #   Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-  #   Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
-  BudgetFunctionArn:
-    Description: "Budget-making Lambda Function ARN"
+  BudgetMakerFunctionArn:
+    Description: 'Budget-making Lambda Function ARN'
     Value: !GetAtt BudgetMakerFunction.Arn
-  BudgetFunctionRoleArn:
-    Description: "IAM Role created for Budget-making function"
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-BudgetMakerFunctionArn'
+  BudgetMakerFunctionRoleArn:
+    Description: 'IAM Role created for Budget-making function'
     Value: !GetAtt BudgetMakerFunctionRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-BudgetMakerFunctionRoleArn'
+  BudgetMakerFunctionPolicyArn:
+    Value: !Ref BudgetMakerFunctionPolicy
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-BudgetMakerFunctionPolicyArn'
+  BudgetMakerNotificationTopicArn:
+    Value: !Ref 'BudgetMakerNotificationTopic'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-BudgetMakerNotificationTopicArn'
+  BudgetMakerNotificationTopicPolicyArn:
+    Value: !Ref 'BudgetMakerNotificationTopicPolicy'
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-BudgetMakerNotificationTopicPolicyArn'

--- a/tests/unit/test_compare_budgets_and_users.py
+++ b/tests/unit/test_compare_budgets_and_users.py
@@ -8,8 +8,8 @@ from botocore.stub import Stubber
 
 from budget import app
 
+@patch.dict('budget.app.configuration', {'account_id': '012345678901'})
 class TestCompareBudgetsAndUsers(unittest.TestCase):
-  fake_account_number = '123456789012'
   # these are very truncated mock responses containing as few fields as possible
   mock_budget_response_1 = {
     'Budgets': [
@@ -36,7 +36,7 @@ class TestCompareBudgetsAndUsers(unittest.TestCase):
       app.get_client = MagicMock(return_value=budgets_client)
       stubber.add_response('describe_budgets', self.mock_budget_response_1)
       user_id_list = ['3388489']
-      user_ids_without_budget, budgets_to_remove = app.compare_budgets_and_users(self.fake_account_number, user_id_list)
+      user_ids_without_budget, budgets_to_remove = app.compare_budgets_and_users(user_id_list)
       expected_without_budget = []
       expected_budgets_to_remove = []
       self.assertCountEqual(user_ids_without_budget, expected_without_budget)
@@ -49,7 +49,7 @@ class TestCompareBudgetsAndUsers(unittest.TestCase):
       app.get_client = MagicMock(return_value=budgets_client)
       stubber.add_response('describe_budgets', self.mock_budget_response_1)
       user_id_list = ['3388489', '1234567']
-      user_ids_without_budget, budgets_to_remove = app.compare_budgets_and_users(self.fake_account_number, user_id_list)
+      user_ids_without_budget, budgets_to_remove = app.compare_budgets_and_users(user_id_list)
       expected_without_budget = ['1234567']
       expected_budgets_to_remove = []
       self.assertCountEqual(user_ids_without_budget, expected_without_budget)
@@ -62,7 +62,7 @@ class TestCompareBudgetsAndUsers(unittest.TestCase):
       app.get_client = MagicMock(return_value=budgets_client)
       stubber.add_response('describe_budgets', self.mock_budget_response_2)
       user_id_list = ['3388489']
-      user_ids_without_budget, budgets_to_remove = app.compare_budgets_and_users(self.fake_account_number, user_id_list)
+      user_ids_without_budget, budgets_to_remove = app.compare_budgets_and_users(user_id_list)
       expected_without_budget = []
       expected_budgets_to_remove = ['1234567']
       self.assertCountEqual(user_ids_without_budget, expected_without_budget)
@@ -75,7 +75,7 @@ class TestCompareBudgetsAndUsers(unittest.TestCase):
       # response includes a budget that uses a different naming convention
       stubber.add_response('describe_budgets', self.mock_budget_response_3)
       user_id_list = ['3388489']
-      user_ids_without_budget, budgets_to_remove = app.compare_budgets_and_users(self.fake_account_number, user_id_list)
+      user_ids_without_budget, budgets_to_remove = app.compare_budgets_and_users(user_id_list)
       expected_without_budget = []
       # the non-service-catalog budget should not show up in this list
       expected_budgets_to_remove = []

--- a/tests/unit/test_create_budgets.py
+++ b/tests/unit/test_create_budgets.py
@@ -1,0 +1,151 @@
+import json
+import unittest
+from unittest.mock import call, MagicMock, patch
+
+import boto3
+from botocore.exceptions import ClientError
+from botocore.stub import Stubber, ANY
+
+from budget import app
+
+
+@patch.dict('budget.app.configuration', {'account_id': '012345678901'})
+class TestCreateBudgets(unittest.TestCase):
+
+  def test_create_budgets_no_new_users(self):
+    no_new_users = []
+    teams_by_user_id = {} # this doesn't matter if there are no new users
+    result = app.create_budgets(no_new_users, teams_by_user_id)
+    # if there are no new users, we expect a message indicating that no
+    # new budgets were created
+    expected = 'Budgets created for synapse ids: none'
+    self.assertEqual(result, expected)
+
+
+  @patch('budget.app.create_budget', MagicMock(return_value={}))
+  @patch('budget.app.create_budget_notifications', MagicMock(return_value={}))
+  @patch.dict('budget.app.TEAM_BUDGET_RULES', {'teams': {'12345': {}}})
+  def test_create_budgets_some_users(self):
+    new_users = ['3406211', '3388489']
+    teams_by_user_id = {'3406211': ['12345'], '3388489': ['12345']}
+    result = app.create_budgets(new_users, teams_by_user_id)
+    # if there are new users, we expect a message that budgets were
+    # created for each of them
+    expected = 'Budgets created for synapse ids: 3406211, 3388489'
+    self.assertEqual(result, expected)
+
+
+  @patch.dict('budget.app.TEAM_BUDGET_RULES', {
+    'teams':{'12345': {'amount': '100','period': 'ANNUALLY'}}
+  })
+  def test_create_budget(self):
+    synapse_id = '3388489'
+    team = '12345'
+    budgets_client = boto3.client('budgets')
+    with Stubber(budgets_client) as stubber:
+      app.get_client = MagicMock(return_value=budgets_client)
+      expected_params = {
+        'AccountId': '012345678901',
+        'Budget': {
+          'BudgetName': 'service-catalog_3388489',
+          'BudgetLimit': {
+            'Amount': '100',
+            'Unit': 'USD'
+          },
+          'CostFilters': {
+            'TagKeyValue': [
+              (
+                'aws:servicecatalog:provisioningPrincipalArn$arn:aws:sts::'
+                '012345678901:assumed-role/ServiceCatalogEndusers/3388489'
+              )
+            ]
+          },
+          'CostTypes': {
+            'IncludeRefund': False,
+            'IncludeCredit': False
+          },
+          'TimeUnit': 'ANNUALLY',
+          'BudgetType': 'COST'
+        }
+      }
+      # verify that the boto3 client will be called with the expected values
+      stubber.add_response('create_budget', {}, expected_params)
+      result = app.create_budget(synapse_id, team)
+      expected = {}
+      self.assertEqual(result, expected)
+
+
+  def test_create_budget_no_team_rules(self):
+    synapse_id = '3388489'
+    team = 'foo'
+    with self.assertRaises(ValueError) as context_manager:
+      app.create_budget(synapse_id, team)
+    expected_error = 'No budget rules available for team foo'
+    self.assertEqual(str(context_manager.exception), expected_error)
+
+
+  @patch.dict('budget.app.TEAM_BUDGET_RULES', {
+    'teams': {
+      '12345': {
+        'amount': '100',
+        'period': 'ANNUALLY',
+        'community_manager_emails': []
+      }
+    }
+  })
+  def test_create_budget_notifications_makes_expected_call_types(self):
+    synapse_id = '3388489'
+    team = '12345'
+    with patch('budget.app._create_budget_notification') as mock:
+      app.create_budget_notifications(synapse_id, team)
+    expected = [
+      call('3388489', 25.0),
+      call('3388489', 50.0),
+      call('3388489', 80.0),
+      call('3388489', 90.0, admin_emails=[]),
+      call('3388489', 100.0, admin_emails=[]),
+      call('3388489', 110.0, admin_emails=[])
+    ]
+    self.assertCountEqual(mock.mock_calls, expected)
+
+
+  def test_create_budget_notification_user_only(self):
+    budgets_client = boto3.client('budgets')
+    fake_topic_arn = 'arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE'
+    with Stubber(budgets_client) as stubber, \
+      patch.dict('budget.app.configuration',
+        {'notification_topic_arn': fake_topic_arn}):
+      app.get_client = MagicMock(return_value=budgets_client)
+      # user only
+      expected_params = {
+        'AccountId': '012345678901',
+        'BudgetName': 'service-catalog_3388489',
+        'Notification': {
+            'NotificationType': 'ACTUAL',
+            'ComparisonOperator': 'GREATER_THAN',
+            'Threshold': 25.0,
+            'ThresholdType': 'PERCENTAGE',
+            'NotificationState': 'ALARM'
+        },
+        'Subscribers': [{
+          'SubscriptionType': 'SNS',
+          'Address': fake_topic_arn
+        }]
+      }
+      # verify that the boto3 client will be called with the expected values
+      stubber.add_response('create_notification', {}, expected_params)
+      synapse_id = '3388489'
+      threshold = 25.0
+      result = app._create_budget_notification(synapse_id, threshold)
+      expected = {}
+      self.assertEqual(result, expected)
+      # now with admins
+      fake_admin_email = 'jane.doe@sagebase.org'
+      expected_params['Subscribers'].insert(0, {
+          'SubscriptionType': 'EMAIL',
+          'Address': fake_admin_email
+        })
+      stubber.add_response('create_notification', {}, expected_params)
+      result = app._create_budget_notification(synapse_id, threshold, admin_emails=[fake_admin_email])
+      expected = {}
+      self.assertEqual(result, expected)

--- a/tests/unit/test_get_env_var.py
+++ b/tests/unit/test_get_env_var.py
@@ -1,0 +1,28 @@
+import json
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from budget import app
+
+
+class TestGetEnvVar(unittest.TestCase):
+  env_var_value = 'some_value'
+  env_var_key = 'SOME_ENV_VAR'
+
+  def test_env_var_present(self):
+    with patch('os.getenv', MagicMock(return_value=self.env_var_value)) as mock:
+      result = app._get_env_var(self.env_var_key)
+    expected = self.env_var_value
+    self.assertEqual(result, expected)
+    mock.assert_called_once_with(self.env_var_key)
+
+
+  def test_env_var_missing(self):
+    with self.assertRaises(ValueError) as context_manager:
+      app._get_env_var(self.env_var_key)
+    expected = (
+      'Lambda configuration error: '
+      f'missing environment variable {self.env_var_key}'
+    )
+    self.assertEqual(str(context_manager.exception), expected)

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -1,10 +1,54 @@
 import json
 import unittest
+from unittest.mock import MagicMock, patch
 
 from budget import app
 
 
 class TestHandler(unittest.TestCase):
 
-  def test_handler(self):
-    pass
+  # This test only looks at how the success message is put together
+  # for the return value. All the functions it calls have their own tests.
+  def test_handler_happy_path(self):
+    with patch('budget.app._set_configuration') as config_mock, \
+      patch('budget.app.get_users',
+        MagicMock(return_value={})) as users_mock, \
+      patch('budget.app.check_user_duplicates',
+        MagicMock(return_value='')) as dupe_mock, \
+      patch('budget.app.compare_budgets_and_users',
+        MagicMock(return_value=([],[]))) as compare_mock, \
+      patch('budget.app.create_budgets',
+        MagicMock(
+          return_value='Budgets created for synapse ids: 3388489')
+        ) as create_mock, \
+      patch('budget.app.delete_budgets',
+        MagicMock(
+          return_value='Budgets removed for synapse ids: 3406211')
+        ) as delete_mock:
+      result = app.lambda_handler({}, {})
+
+    expected = {
+      'message': (
+        'Budget maker run complete; '
+        'Budgets created for synapse ids: 3388489; '
+        'Budgets removed for synapse ids: 3406211'
+      )}
+    self.assertEqual(result, expected)
+    config_mock.assert_called_once()
+    users_mock.assert_called_once()
+    dupe_mock.assert_called_once()
+    compare_mock.assert_called_once()
+    create_mock.assert_called_once()
+    delete_mock.assert_called_once()
+
+
+  # Test general error handling
+  def test_handler_unhappy_path(self):
+    result = app.lambda_handler({}, {})
+    expected = {
+      'error': (
+        'Lambda configuration error: missing environment variable '
+        'AWS_ACCOUNT_ID'
+      )
+    }
+    self.assertEqual(result, expected)


### PR DESCRIPTION
- creates budgets
- adds SNS topic
- makes lambda configurable through environment variables

The following remains to be done in follow-on PRs:
- budget removal
- remaining lambda configuration
- use `synapseclient` instead of `requests` when SYNPY-1084 is in production  
- time permitting, some improvement on handling of duplicates