### PR TITLE
Bump limit on synapse api call

### DIFF
--- a/budget/config.py
+++ b/budget/config.py
@@ -141,7 +141,7 @@ class Config:
 
 
   def get_synapse_team_member_url(self, team_id):
-    return f'{self.synapse_team_member_list_endpoint}/{team_id}'
+    return f'{self.synapse_team_member_list_endpoint}/{team_id}?limit=50'
 
 
   def _get_env_var(name):


### PR DESCRIPTION
One-liner -- bump limit on results returned to max. This is a temporary solution until the refactor to use the synapseclient directly is available w/o authing.
